### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*.eslintcache


### PR DESCRIPTION
Created a gitignore, `.eslintcache` files are cache files for local editing and should not be pushed, they will cause a lot of merge conflicts